### PR TITLE
Some updates

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,8 +37,11 @@ focus removes complexity that can cause false failures in your testing
 This reduction of complexity naturally leads to a *more stable build*.
 
 Free of dependencies, EMake is faster to install.  In my own projects,
-switching from Cask to EMake reduced build time by 90 seconds.  While
-we surely shouldn't be /too/ concerned about some faceless VM's time, we
+switching from Cask to EMake reduced build time by 90 seconds.  Thanks
+to pre-built binaries provided by [[https://github.com/rejeep/evm][EVM]], the average installation time
+(i.e., everything after container spinup and before your tests run)
+takes less than ten seconds for a released version of Emacs.  While we
+surely shouldn't be /too/ concerned about some faceless VM's time, we
 should be *good stewards* of the resources freely provided to us.
 
 Because it relies only on existing tools, EMake is more pliable than

--- a/emake.el
+++ b/emake.el
@@ -142,10 +142,9 @@ Used in companion file `emake.mk'."
   "Print a message to standard out.
 Argument FORMAT is a format string.  Optional argument ARGS is a
 list of arguments for that format string."
-  (princ
-   (apply #'format
-          (concat "\033[0;37memake:\033[0m " format "\n")
-          args)))
+  (let ((s (apply #'format format args)))
+    (princ (concat "\033[0;37memake:\033[0m " s "\n"))
+    s))
 
 (defmacro emake-task (description &rest body)
   "Wrapped by DESCRIPTION messages, run BODY."

--- a/emake.el
+++ b/emake.el
@@ -166,9 +166,16 @@ list of arguments for that format string."
     (emake-task "determining package descriptor"
       (or
        (emake-task "looking for *-pkg.el file"
-         (emake--message (expand-file-name package-file))
-         (emake--message (file-name-directory (expand-file-name package-file)))
-         (package-load-descriptor (file-name-directory (expand-file-name package-file))))
+         ;; `package--description-file' is slightly broken in this
+         ;; case.  It relies on the name of directory passed to
+         ;; `package-load-descriptor'.  The directory name is not
+         ;; always reliable, though, for obvious reasons.
+
+         ;; We have some special knowledge about the package provided
+         ;; to us via environment variables; use it to provide an
+         ;; alternative definition for `package--description-file'.
+         (cl-flet ((package--description-file (_pkg-dir) (concat (file-name-base package-file) "-pkg.el")))
+           (package-load-descriptor (file-name-directory (expand-file-name package-file)))))
        (progn
          (emake--message "didn't find a package descriptor")
          (emake-task (format "parsing headers in %S" package-file)

--- a/emake.el
+++ b/emake.el
@@ -180,10 +180,8 @@ list of arguments for that format string."
 
 (defvar emake-package-reqs
   (when emake-package-desc
-    (delq nil (mapcar (lambda (x)
-                        (unless (eq (car x) 'emacs)
-                          x))
-                      (package-desc-reqs emake-package-desc))))
+    (cl-remove-if (lambda (x) (eq (car x) 'emacs))
+                  (package-desc-reqs emake-package-desc)))
   "Non-emacs dependencies of PACKAGE_FILE.")
 
 (defvar emake-project-root

--- a/emake.mk
+++ b/emake.mk
@@ -167,4 +167,6 @@ endif
 install-emacs-travis: $(EMAKE_WORKDIR)/emacs-travis.mk
 
 install-evm:
+ifeq ($(wildcard "$(HOME)/.evm/."),)
 	git clone "https://github.com/rejeep/evm.git" "$(HOME)/.evm"
+endif

--- a/emake.mk
+++ b/emake.mk
@@ -66,7 +66,7 @@ help-%: emake ## show help for EMake target '%'
 
 ## Commands useful for Travis
 
-setup: emake ## install emacs/emake
+setup: emacs emake ## install emacs/emake
 
 install: $(EMAKE_WORKDIR)/elpa ## install dependencies as determined by EMake
 
@@ -108,10 +108,15 @@ $(EMAKE_WORKDIR)/emacs-travis.mk: $(EMAKE_WORKDIR)
 $(EMAKE_WORKDIR)/elpa: $(EMAKE_WORKDIR)/emake.el
 	$(EMAKE) install
 
-emake: emacs $(EMAKE_WORKDIR)/emake.el
-emacs: $(EMAKE_WORKDIR)/emake.el
-	$(EMACS) -batch -l '$(EMAKE_WORKDIR)/emake.el' -f emake-verify-version || $(MAKE) install-emacs
+emake: $(EMAKE_WORKDIR)/emake.el
+
+ifeq ($(CI),true)
+emacs: install-emacs
 	$(EMACS) --version
+else
+emacs: $(EMAKE_WORKDIR)/emake.el
+	$(EMACS) -batch -l '$(EMAKE_WORKDIR)/emake.el' -f emake-verify-version || $(error Wrong version!)
+endif
 
 install-emacs: $(EMAKE_WORKDIR)/emacs-travis.mk
 	export PATH="$(HOME)/bin:$(PATH)"


### PR DESCRIPTION
Summary:

* We now use EVM when we can! Fix #28 (in spirit).
* Some CL macros are taken advantage of
* Protections against blowing away your own emacs installation
* Ability to use a `*-pkg.el` file as the package descriptor instead of parsing from headers (and some messages that make it possible to know which method was chosen)